### PR TITLE
Include header files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft lib

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,5 @@ setup(
                      'lib/crcany/model.c',
                      'lib/crcany/crc.c']
         )
-    ],
-    package_data={'': ['lib']}
+    ]
 )


### PR DESCRIPTION
Without them, compilation fails like

```
lib/crcany/crc.c:12:10: fatal error: crc.h: No such file or directory
   12 | #include "crc.h"
      |          ^~~~~~~
compilation terminated.
```

You can also see this by trying to build a wheel like `python -m build .`