### PR TITLE
Add license metadata to wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "anycrc"
 version = "1.3.2"
 description = "The fastest Python CRC Library"
 readme = "README.md"
+license = {text = "Zlib"}
 requires-python = ">=3.7"
 
 [project.urls]


### PR DESCRIPTION
By adding the SPDX identifier, the license info should appear in the project meta on PyPI.